### PR TITLE
Fix planner_server name in navigation.yaml

### DIFF
--- a/linorobot2_navigation/config/navigation.yaml
+++ b/linorobot2_navigation/config/navigation.yaml
@@ -365,7 +365,7 @@ planner_server:
     use_sim_time: false
     planner_plugins: ["GridBased"]
     GridBased:
-      plugin: "nav2_navfn_planner/NavfnPlanner"
+      plugin: "nav2_navfn_planner::NavfnPlanner"
       tolerance: 0.5
       use_astar: false
       allow_unknown: true


### PR DESCRIPTION
By comparison with jazzy nav2 config file, the correct syntax is nav2_navfn_planner::navfnPlanner. i.e. replace / with ::. 

This error was causing failure to create the global planner, with the error message: [component_container_isolated-1] [FATAL] [1741058705.636395136] [planner_server]: Failed to create global planner. Exception: According to the loaded plugin descriptions the class nav2_navfn_planner/NavfnPlanner with base class type nav2_core::GlobalPlanner does not exist. Declared types are  nav2_navfn_planner::NavfnPlanner nav2_smac_planner::SmacPlanner2D nav2_smac_planner::SmacPlannerHybrid nav2_smac_planner::SmacPlannerLattice nav2_theta_star_planner::ThetaStarPlanner