### PR TITLE
Update navigation.yaml to match the default for nav2 on jazzy

### DIFF
--- a/linorobot2_navigation/config/navigation.yaml
+++ b/linorobot2_navigation/config/navigation.yaml
@@ -1,33 +1,33 @@
 amcl:
   ros__parameters:
-    use_sim_time: false
     alpha1: 0.2
     alpha2: 0.2
     alpha3: 0.2
     alpha4: 0.2
     alpha5: 0.2
-    base_frame_id: "base_footprint"
+    base_frame_id: base_footprint
     beam_skip_distance: 0.5
     beam_skip_error_threshold: 0.9
     beam_skip_threshold: 0.3
     do_beamskip: false
-    global_frame_id: "map"
+    global_frame_id: map
     lambda_short: 0.1
     laser_likelihood_max_dist: 2.0
     laser_max_range: 100.0
     laser_min_range: -1.0
-    laser_model_type: "likelihood_field"
+    laser_model_type: likelihood_field
     max_beams: 60
     max_particles: 2000
     min_particles: 500
-    odom_frame_id: "odom"
+    odom_frame_id: odom
     pf_err: 0.05
     pf_z: 0.99
     recovery_alpha_fast: 0.0
     recovery_alpha_slow: 0.0
     resample_interval: 1
-    robot_model_type: "nav2_amcl::DifferentialMotionModel"
+    robot_model_type: nav2_amcl::DifferentialMotionModel
     save_pose_rate: 0.5
+    scan_topic: scan
     sigma_hit: 0.2
     tf_broadcast: true
     transform_tolerance: 1.0
@@ -37,388 +37,387 @@ amcl:
     z_max: 0.05
     z_rand: 0.5
     z_short: 0.05
-    scan_topic: scan
-
-amcl_map_client:
+behavior_server:
   ros__parameters:
-    use_sim_time: false
-
-amcl_rclcpp_node:
-  ros__parameters:
-    use_sim_time: false
-
+    assisted_teleop:
+      plugin: nav2_behaviors::AssistedTeleop
+    backup:
+      plugin: nav2_behaviors::BackUp
+    behavior_plugins:
+    - spin
+    - backup
+    - drive_on_heading
+    - assisted_teleop
+    - wait
+    cycle_frequency: 10.0
+    drive_on_heading:
+      plugin: nav2_behaviors::DriveOnHeading
+    global_costmap_topic: global_costmap/costmap_raw
+    global_footprint_topic: global_costmap/published_footprint
+    global_frame: map
+    local_costmap_topic: local_costmap/costmap_raw
+    local_footprint_topic: local_costmap/published_footprint
+    local_frame: odom
+    max_rotational_vel: 1.0
+    min_rotational_vel: 0.4
+    robot_base_frame: base_link
+    rotational_acc_lim: 3.2
+    simulate_ahead_time: 2.0
+    spin:
+      plugin: nav2_behaviors::Spin
+    transform_tolerance: 0.1
+    wait:
+      plugin: nav2_behaviors::Wait
 bt_navigator:
   ros__parameters:
-    use_sim_time: false
-    global_frame: map
-    robot_base_frame: base_link
-    odom_topic: /odom
+    action_server_result_timeout: 900.0
     bt_loop_duration: 10
     default_server_timeout: 20
-    enable_groot_monitoring: true
-    groot_zmq_publisher_port: 1666
-    groot_zmq_server_port: 1667
-    plugin_lib_names:
-    - nav2_compute_path_to_pose_action_bt_node
-    - nav2_compute_path_through_poses_action_bt_node
-    - nav2_follow_path_action_bt_node
-    - nav2_back_up_action_bt_node
-    - nav2_spin_action_bt_node
-    - nav2_wait_action_bt_node
-    - nav2_clear_costmap_service_bt_node
-    - nav2_is_stuck_condition_bt_node
-    - nav2_goal_reached_condition_bt_node
-    - nav2_goal_updated_condition_bt_node
-    - nav2_initial_pose_received_condition_bt_node
-    - nav2_reinitialize_global_localization_service_bt_node
-    - nav2_rate_controller_bt_node
-    - nav2_distance_controller_bt_node
-    - nav2_speed_controller_bt_node
-    - nav2_truncate_path_action_bt_node
-    - nav2_goal_updater_node_bt_node
-    - nav2_recovery_node_bt_node
-    - nav2_pipeline_sequence_bt_node
-    - nav2_round_robin_node_bt_node
-    - nav2_transform_available_condition_bt_node
-    - nav2_time_expired_condition_bt_node
-    - nav2_distance_traveled_condition_bt_node
-    - nav2_single_trigger_bt_node
-    - nav2_is_battery_low_condition_bt_node
-    - nav2_navigate_through_poses_action_bt_node
-    - nav2_navigate_to_pose_action_bt_node
-    - nav2_remove_passed_goals_action_bt_node
-    - nav2_planner_selector_bt_node
-    - nav2_controller_selector_bt_node
-    - nav2_goal_checker_selector_bt_node
-
-bt_navigator_rclcpp_node:
+    error_code_names:
+    - compute_path_error_code
+    - follow_path_error_code
+    global_frame: map
+    navigate_through_poses:
+      plugin: nav2_bt_navigator::NavigateThroughPosesNavigator
+    navigate_to_pose:
+      plugin: nav2_bt_navigator::NavigateToPoseNavigator
+    navigators:
+    - navigate_to_pose
+    - navigate_through_poses
+    odom_topic: /odom
+    robot_base_frame: base_link
+    wait_for_service_timeout: 1000
+collision_monitor:
   ros__parameters:
-    use_sim_time: false
-
+    FootprintApproach:
+      action_type: approach
+      enabled: true
+      footprint_topic: /local_costmap/published_footprint
+      min_points: 6
+      simulation_time_step: 0.1
+      time_before_collision: 1.2
+      type: polygon
+      visualize: false
+    base_frame_id: base_footprint
+    base_shift_correction: true
+    cmd_vel_in_topic: cmd_vel_smoothed
+    cmd_vel_out_topic: cmd_vel
+    observation_sources:
+    - scan
+    odom_frame_id: odom
+    polygons:
+    - FootprintApproach
+    scan:
+      enabled: true
+      max_height: 2.0
+      min_height: 0.15
+      topic: scan
+      type: scan
+    source_timeout: 1.0
+    state_topic: collision_monitor_state
+    stop_pub_timeout: 2.0
+    transform_tolerance: 0.2
 controller_server:
   ros__parameters:
-    use_sim_time: false
+    FollowPath:
+      AckermannConstraints:
+        min_turning_r: 0.2
+      ConstraintCritic:
+        cost_power: 1
+        cost_weight: 4.0
+        enabled: true
+      CostCritic:
+        collision_cost: 1000000.0
+        consider_footprint: true
+        cost_power: 1
+        cost_weight: 3.81
+        critical_cost: 300.0
+        enabled: true
+        near_goal_distance: 1.0
+        trajectory_point_step: 2
+      GoalAngleCritic:
+        cost_power: 1
+        cost_weight: 3.0
+        enabled: true
+        threshold_to_consider: 0.5
+      GoalCritic:
+        cost_power: 1
+        cost_weight: 5.0
+        enabled: true
+        threshold_to_consider: 1.4
+      PathAlignCritic:
+        cost_power: 1
+        cost_weight: 14.0
+        enabled: true
+        max_path_occupancy_ratio: 0.05
+        offset_from_furthest: 20
+        threshold_to_consider: 0.5
+        trajectory_point_step: 4
+        use_path_orientations: false
+      PathAngleCritic:
+        cost_power: 1
+        cost_weight: 2.0
+        enabled: true
+        max_angle_to_furthest: 1.0
+        mode: 0
+        offset_from_furthest: 4
+        threshold_to_consider: 0.5
+      PathFollowCritic:
+        cost_power: 1
+        cost_weight: 5.0
+        enabled: true
+        offset_from_furthest: 5
+        threshold_to_consider: 1.4
+      PreferForwardCritic:
+        cost_power: 1
+        cost_weight: 5.0
+        enabled: true
+        threshold_to_consider: 0.5
+      TrajectoryVisualizer:
+        time_step: 3
+        trajectory_step: 5
+      ax_max: 3.0
+      ax_min: -3.0
+      ay_max: 3.0
+      az_max: 3.5
+      batch_size: 2000
+      critics:
+      - ConstraintCritic
+      - CostCritic
+      - GoalCritic
+      - GoalAngleCritic
+      - PathAlignCritic
+      - PathFollowCritic
+      - PathAngleCritic
+      - PreferForwardCritic
+      gamma: 0.015
+      iteration_count: 1
+      model_dt: 0.05
+      motion_model: DiffDrive
+      plugin: nav2_mppi_controller::MPPIController
+      prune_distance: 1.7
+      regenerate_noises: true
+      temperature: 0.3
+      time_steps: 56
+      transform_tolerance: 0.1
+      visualize: true
+      vx_max: 0.5
+      vx_min: -0.35
+      vx_std: 0.2
+      vy_max: 0.5
+      vy_std: 0.2
+      wz_max: 1.9
+      wz_std: 0.4
     controller_frequency: 20.0
-    min_x_velocity_threshold: 0.001
-    min_y_velocity_threshold: 0.5
-    min_theta_velocity_threshold: 0.001
+    controller_plugins:
+    - FollowPath
+    costmap_update_timeout: 0.3
     failure_tolerance: 0.3
-    progress_checker_plugin: "progress_checker"
-    goal_checker_plugins: ["general_goal_checker"] # "precise_goal_checker"
-    controller_plugins: ["FollowPath"]
-
-    # Progress checker parameters
-    progress_checker:
-      plugin: "nav2_controller::SimpleProgressChecker"
-      required_movement_radius: 0.5
-      movement_time_allowance: 10.0
-
-    # Goal checker parameters
     general_goal_checker:
+      plugin: nav2_controller::SimpleGoalChecker
       stateful: true
-      plugin: "nav2_controller::SimpleGoalChecker"
       xy_goal_tolerance: 0.25
       yaw_goal_tolerance: 0.25
-    # DWB parameters
-    FollowPath:
-      plugin: "nav2_rotation_shim_controller::RotationShimController"
-      angular_dist_threshold: 0.785
-      forward_sampling_distance: 0.5
-      rotate_to_heading_angular_vel: 1.8
-      max_angular_accel: 3.2
-      simulate_ahead_time: 1.0
-      plugin: "dwb_core::DWBLocalPlanner"
-      debug_trajectory_details: true
-      min_vel_x: 0.0
-      min_vel_y: 0.0
-      max_vel_x: 0.4
-      max_vel_y: 0.0
-      max_vel_theta: 0.75
-      min_speed_xy: 0.0
-      max_speed_xy: 0.4
-      min_speed_theta: 0.0
-      # Add high threshold velocity for turtlebot 3 issue.
-      # https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/75
-      acc_lim_x: 2.5
-      acc_lim_y: 0.0
-      acc_lim_theta: 3.2
-      decel_lim_x: -2.5
-      decel_lim_y: 0.0
-      decel_lim_theta: -3.2
-      vx_samples: 20
-      vy_samples: 5
-      vtheta_samples: 20
-      sim_time: 1.7
-      linear_granularity: 0.05
-      angular_granularity: 0.025
-      transform_tolerance: 0.2
-      xy_goal_tolerance: 0.25
-      trans_stopped_velocity: 0.25
-      short_circuit_trajectory_evaluation: true
-      stateful: true
-      critics: ["RotateToGoal", "Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
-      BaseObstacle.scale: 0.02
-      PathAlign.scale: 32.0
-      PathAlign.forward_point_distance: 0.1
-      GoalAlign.scale: 24.0
-      GoalAlign.forward_point_distance: 0.1
-      PathDist.scale: 32.0
-      GoalDist.scale: 24.0
-      RotateToGoal.scale: 32.0
-      RotateToGoal.slowing_factor: 5.0
-      RotateToGoal.lookahead_time: -1.0
-
-controller_server_rclcpp_node:
+    goal_checker_plugins:
+    - general_goal_checker
+    min_theta_velocity_threshold: 0.001
+    min_x_velocity_threshold: 0.001
+    min_y_velocity_threshold: 0.5
+    progress_checker:
+      movement_time_allowance: 10.0
+      plugin: nav2_controller::SimpleProgressChecker
+      required_movement_radius: 0.5
+    progress_checker_plugins:
+    - progress_checker
+    use_realtime_priority: false
+docking_server:
   ros__parameters:
-    use_sim_time: false
-
+    base_frame: base_link
+    controller:
+      costmap_topic: /local_costmap/costmap_raw
+      dock_collision_threshold: 0.3
+      footprint_topic: /local_costmap/published_footprint
+      k_delta: 2.0
+      k_phi: 3.0
+      projection_time: 5.0
+      simulation_step: 0.1
+      transform_tolerance: 0.1
+      use_collision_detection: true
+      v_linear_max: 0.15
+      v_linear_min: 0.15
+    controller_frequency: 50.0
+    dock_approach_timeout: 30.0
+    dock_backwards: false
+    dock_plugins:
+    - simple_charging_dock
+    dock_prestaging_tolerance: 0.5
+    fixed_frame: odom
+    initial_perception_timeout: 5.0
+    max_retries: 3
+    simple_charging_dock:
+      docking_threshold: 0.05
+      external_detection_rotation_pitch: -1.57
+      external_detection_rotation_roll: -1.57
+      external_detection_rotation_yaw: 0.0
+      external_detection_timeout: 1.0
+      external_detection_translation_x: -0.18
+      external_detection_translation_y: 0.0
+      filter_coef: 0.1
+      plugin: opennav_docking::SimpleChargingDock
+      staging_x_offset: -0.7
+      use_battery_status: false
+      use_external_detection_pose: true
+      use_stall_detection: false
+    undock_angular_tolerance: 0.1
+    undock_linear_tolerance: 0.05
+    wait_charge_timeout: 5.0
 global_costmap:
   global_costmap:
     ros__parameters:
-      use_sim_time: false
-      footprint_padding: 0.03
-      update_frequency: 1.0
-      publish_frequency: 1.0
-      global_frame: map
-      robot_base_frame: base_link
-      robot_radius: 0.22 # radius set and used, so no footprint points
-      resolution: 0.05
-      plugins: ["static_layer", "obstacle_layer", "voxel_layer", "sonar_layer", "inflation_layer"]
-      obstacle_layer:
-        plugin: "nav2_costmap_2d::ObstacleLayer"
-        enabled: true
-        observation_sources: scan base_scan
-        footprint_clearing_enabled: true
-        max_obstacle_height: 2.0
-        combination_method: 1
-        scan:
-          topic: /scan
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          max_obstacle_height: 2.0
-          min_obstacle_height: 0.0
-          clearing: true
-          marking: true
-          data_type: "LaserScan"
-          inf_is_valid: false
-        base_scan:
-          topic: /base/scan
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          max_obstacle_height: 2.0
-          min_obstacle_height: 0.0
-          clearing: true
-          marking: true
-          data_type: "LaserScan"
-          inf_is_valid: false
-      voxel_layer:
-        plugin: "nav2_costmap_2d::VoxelLayer"
-        enabled: true
-        footprint_clearing_enabled: true
-        max_obstacle_height: 2.0
-        publish_voxel_map: true
-        origin_z: 0.0
-        z_resolution: 0.05
-        z_voxels: 16
-        max_obstacle_height: 2.0
-        unknown_threshold: 15
-        mark_threshold: 0
-        observation_sources: pointcloud
-        combination_method: 1
-        pointcloud:  # no frame set, uses frame from message
-          topic: /camera/depth/color/points
-          max_obstacle_height: 2.0
-          min_obstacle_height: 0.01
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          clearing: true
-          marking: true
-          data_type: "PointCloud2"
-      static_layer:
-        plugin: "nav2_costmap_2d::StaticLayer"
-        map_subscribe_transient_local: true
-        enabled: true
-        subscribe_to_updates: true
-        transform_tolerance: 0.1
-      sonar_layer:
-        plugin: "nav2_costmap_2d::RangeSensorLayer"
-        enabled: True
-        topics: ["/sonar"]
-        no_readings_timeout: 0.0
-        clear_on_max_reading: true
-      inflation_layer:
-        plugin: "nav2_costmap_2d::InflationLayer"
-        enabled: true
-        inflation_radius: 0.55
-        cost_scaling_factor: 1.0
-        inflate_unknown: false
-        inflate_around_unknown: true
       always_send_full_costmap: true
-
+      global_frame: map
+      inflation_layer:
+        cost_scaling_factor: 3.0
+        inflation_radius: 0.7
+        plugin: nav2_costmap_2d::InflationLayer
+      obstacle_layer:
+        enabled: true
+        observation_sources: scan
+        plugin: nav2_costmap_2d::ObstacleLayer
+        scan:
+          clearing: true
+          data_type: LaserScan
+          marking: true
+          max_obstacle_height: 2.0
+          obstacle_max_range: 2.5
+          obstacle_min_range: 0.0
+          raytrace_max_range: 3.0
+          raytrace_min_range: 0.0
+          topic: /scan
+      plugins:
+      - static_layer
+      - obstacle_layer
+      - inflation_layer
+      publish_frequency: 1.0
+      resolution: 0.05
+      robot_base_frame: base_link
+      robot_radius: 0.22
+      static_layer:
+        map_subscribe_transient_local: true
+        plugin: nav2_costmap_2d::StaticLayer
+      track_unknown_space: true
+      update_frequency: 1.0
 local_costmap:
   local_costmap:
     ros__parameters:
-      use_sim_time: false
-      update_frequency: 5.0
-      publish_frequency: 2.0
+      always_send_full_costmap: true
       global_frame: odom
-      robot_base_frame: base_link
-      rolling_window: true
-      width: 3
       height: 3
+      inflation_layer:
+        cost_scaling_factor: 3.0
+        inflation_radius: 0.7
+        plugin: nav2_costmap_2d::InflationLayer
+      plugins:
+      - voxel_layer
+      - inflation_layer
+      publish_frequency: 2.0
       resolution: 0.05
-      robot_radius: 0.22 # radius set and used, so no footprint points
-      resolution: 0.05
-      plugins: ["obstacle_layer", "voxel_layer", "sonar_layer", "inflation_layer"]
-      obstacle_layer:
-        plugin: "nav2_costmap_2d::ObstacleLayer"
-        enabled: true
-        observation_sources: scan base_scan
-        footprint_clearing_enabled: true
-        max_obstacle_height: 2.0
-        combination_method: 1
-        scan:
-          topic: /scan
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          max_obstacle_height: 2.0
-          min_obstacle_height: 0.0
-          clearing: false
-          marking: true
-          data_type: "LaserScan"
-          inf_is_valid: false
-        base_scan:
-          topic: /base/scan
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          max_obstacle_height: 2.0
-          min_obstacle_height: 0.0
-          clearing: false
-          marking: true
-          data_type: "LaserScan"
-          inf_is_valid: false
+      robot_base_frame: base_link
+      robot_radius: 0.22
+      rolling_window: true
+      static_layer:
+        map_subscribe_transient_local: true
+        plugin: nav2_costmap_2d::StaticLayer
+      update_frequency: 5.0
       voxel_layer:
-        plugin: "nav2_costmap_2d::VoxelLayer"
         enabled: true
-        footprint_clearing_enabled: true
+        mark_threshold: 0
         max_obstacle_height: 2.0
-        publish_voxel_map: true
+        observation_sources: scan
         origin_z: 0.0
+        plugin: nav2_costmap_2d::VoxelLayer
+        publish_voxel_map: true
+        scan:
+          clearing: true
+          data_type: LaserScan
+          marking: true
+          max_obstacle_height: 2.0
+          obstacle_max_range: 2.5
+          obstacle_min_range: 0.0
+          raytrace_max_range: 3.0
+          raytrace_min_range: 0.0
+          topic: /scan
         z_resolution: 0.05
         z_voxels: 16
-        max_obstacle_height: 2.0
-        unknown_threshold: 15
-        mark_threshold: 0
-        observation_sources: pointcloud
-        combination_method: 1
-        pointcloud:  # no frame set, uses frame from message
-          topic: /camera/depth/color/points
-          max_obstacle_height: 2.0
-          min_obstacle_height: 0.01
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          clearing: true
-          marking: true
-          data_type: "PointCloud2"
-      sonar_layer:
-        plugin: "nav2_costmap_2d::RangeSensorLayer"
-        enabled: True
-        topics: ["/sonar"]
-        no_readings_timeout: 0.0
-        clear_on_max_reading: true
-      inflation_layer:
-        plugin: "nav2_costmap_2d::InflationLayer"
-        enabled: true
-        inflation_radius: 0.55
-        cost_scaling_factor: 1.0
-        inflate_unknown: false
-        inflate_around_unknown: true
-
-map_server:
+      width: 3
+loopback_simulator:
   ros__parameters:
-    use_sim_time: false
-    yaml_filename: "turtlebot3_world.yaml"
-
+    base_frame_id: base_footprint
+    map_frame_id: map
+    odom_frame_id: odom
+    scan_frame_id: base_scan
+    update_duration: 0.02
 map_saver:
   ros__parameters:
-    use_sim_time: false
-    save_map_timeout: 5.0
     free_thresh_default: 0.25
-    occupied_thresh_default: 0.65
     map_subscribe_transient_local: true
-
+    occupied_thresh_default: 0.65
+    save_map_timeout: 5.0
 planner_server:
   ros__parameters:
-    expected_planner_frequency: 20.0
-    use_sim_time: false
-    planner_plugins: ["GridBased"]
     GridBased:
-      plugin: "nav2_navfn_planner/NavfnPlanner"
+      allow_unknown: true
+      plugin: nav2_navfn_planner::NavfnPlanner
       tolerance: 0.5
       use_astar: false
-      allow_unknown: true
-
-planner_server_rclcpp_node:
+    costmap_update_timeout: 1.0
+    expected_planner_frequency: 20.0
+    planner_plugins:
+    - GridBased
+smoother_server:
   ros__parameters:
-    use_sim_time: false
-
-recoveries_server:
-  ros__parameters:
-    costmap_topic: local_costmap/costmap_raw
-    footprint_topic: local_costmap/published_footprint
-    cycle_frequency: 10.0
-    recovery_plugins: ["spin", "backup", "wait"]
-    spin:
-      plugin: "nav2_recoveries/Spin"
-    backup:
-      plugin: "nav2_recoveries/BackUp"
-    wait:
-      plugin: "nav2_recoveries/Wait"
-    global_frame: odom
-    robot_base_frame: base_link
-    transform_timeout: 0.1
-    use_sim_time: false
-    simulate_ahead_time: 2.0
-    max_rotational_vel: 1.0
-    min_rotational_vel: 0.4
-    rotational_acc_lim: 3.2
-
-robot_state_publisher:
-  ros__parameters:
-    use_sim_time: false
-
-waypoint_follower:
-  ros__parameters:
-    loop_rate: 20
-    stop_on_failure: false
-    waypoint_task_executor_plugin: "wait_at_waypoint"
-    wait_at_waypoint:
-      plugin: "nav2_waypoint_follower::WaitAtWaypoint"
-      enabled: true
-      waypoint_pause_duration: 200
-
+    simple_smoother:
+      do_refinement: true
+      max_its: 1000
+      plugin: nav2_smoother::SimpleSmoother
+      tolerance: 1.0e-10
+    smoother_plugins:
+    - simple_smoother
 velocity_smoother:
   ros__parameters:
-    smoothing_frequency: 20.0
-    scale_velocities: False
-    feedback: "OPEN_LOOP"
-    max_velocity: [0.5, 0.0, 2.5]
-    min_velocity: [-0.5, 0.0, -2.5]
-    max_accel: [2.5, 0.0, 3.2]
-    max_decel: [-2.5, 0.0, -3.2]
-    odom_topic: "odom"
+    deadband_velocity:
+    - 0.0
+    - 0.0
+    - 0.0
+    feedback: OPEN_LOOP
+    max_accel:
+    - 2.5
+    - 0.0
+    - 3.2
+    max_decel:
+    - -2.5
+    - 0.0
+    - -3.2
+    max_velocity:
+    - 0.5
+    - 0.0
+    - 2.0
+    min_velocity:
+    - -0.5
+    - 0.0
+    - -2.0
     odom_duration: 0.1
-    deadband_velocity: [0.0, 0.0, 0.0]
+    odom_topic: odom
+    scale_velocities: false
+    smoothing_frequency: 20.0
     velocity_timeout: 1.0
+waypoint_follower:
+  ros__parameters:
+    action_server_result_timeout: 900.0
+    loop_rate: 20
+    stop_on_failure: false
+    wait_at_waypoint:
+      enabled: true
+      plugin: nav2_waypoint_follower::WaitAtWaypoint
+      waypoint_pause_duration: 200
+    waypoint_task_executor_plugin: wait_at_waypoint


### PR DESCRIPTION
The navigation.yaml in the repo almost completely dates back to pre-jazzy, and its layout was so different from the default that nav2 on Jazzy deposits in /tmp when run with: ros2 launch nav2_bringup bringup_launch.py use_sim_time:=False autostart:=True map:=/path/to/your-map.yaml that comparison wasn't really possible. Furthermore, the nav stack was unable to navigate to a goal using the previous navigation.yaml.

Problems found were:
1. it had a syntax error in naming a plugin: line 368 contained: plugin: "nav2_navfn_planner/NavfnPlanner" should have been: plugin: "nav2_navfn_planner::NavfnPlanner" so it could never work.
2. After fixing this, attempting to navigate gave errors like: [component_container_isolated-1] [INFO] [1741063958.773577902] [amcl]: Setting pose (1741063958.773578): -0.104 -0.005 1.851 [rviz2-2] Start navigation [rviz2-2] [ERROR] [1741063991.586034117] [rviz_navigation_dialog_action_client]: navigate_to_pose action server is not available. Is the initial pose set?

The best course of action seems to be to bring it up to date with the default Jazzy nav2 config, which does navigate a real 2wd robot successfully.

Thomas Chou had made 2 changes to navigation.yaml:
1. Reduced the 3rd parameter in max and min speed from 2.5 to 2.0. This seems like a difference not appropriate for incorporating in a "basic-working" navigation.yaml
2. Added sonar support in commit on 2024-07-06. I looked at adding it into the nav2 default which is the subject of this PR, but the format of configuration around it was so different that it couldn't be put in the same way it was in the previous file. For example, the prevous file had the global planner looking at the voxel layer, and T. Chou had added a sonar layer to the global planner, whereas the current jazzy default does not look at the voxel layer in the global planner, only in the local planner. Also, the format for declaring plugins seemed to have changed. I recommend that if a sonar layer should be re-introduced, it is done in the context of this Jazzy nav2 config.