### PR TITLE
fix navigation.yaml & rviz to match nav2_bringup

### DIFF
--- a/linorobot2_navigation/config/navigation.yaml
+++ b/linorobot2_navigation/config/navigation.yaml
@@ -5,29 +5,28 @@ amcl:
     alpha3: 0.2
     alpha4: 0.2
     alpha5: 0.2
-    base_frame_id: base_footprint
+    base_frame_id: "base_footprint"
     beam_skip_distance: 0.5
     beam_skip_error_threshold: 0.9
     beam_skip_threshold: 0.3
     do_beamskip: false
-    global_frame_id: map
+    global_frame_id: "map"
     lambda_short: 0.1
     laser_likelihood_max_dist: 2.0
     laser_max_range: 100.0
     laser_min_range: -1.0
-    laser_model_type: likelihood_field
+    laser_model_type: "likelihood_field"
     max_beams: 60
     max_particles: 2000
     min_particles: 500
-    odom_frame_id: odom
+    odom_frame_id: "odom"
     pf_err: 0.05
     pf_z: 0.99
     recovery_alpha_fast: 0.0
     recovery_alpha_slow: 0.0
     resample_interval: 1
-    robot_model_type: nav2_amcl::DifferentialMotionModel
+    robot_model_type: "nav2_amcl::DifferentialMotionModel"
     save_pose_rate: 0.5
-    scan_topic: scan
     sigma_hit: 0.2
     tf_broadcast: true
     transform_tolerance: 1.0
@@ -37,387 +36,403 @@ amcl:
     z_max: 0.05
     z_rand: 0.5
     z_short: 0.05
-behavior_server:
-  ros__parameters:
-    assisted_teleop:
-      plugin: nav2_behaviors::AssistedTeleop
-    backup:
-      plugin: nav2_behaviors::BackUp
-    behavior_plugins:
-    - spin
-    - backup
-    - drive_on_heading
-    - assisted_teleop
-    - wait
-    cycle_frequency: 10.0
-    drive_on_heading:
-      plugin: nav2_behaviors::DriveOnHeading
-    global_costmap_topic: global_costmap/costmap_raw
-    global_footprint_topic: global_costmap/published_footprint
-    global_frame: map
-    local_costmap_topic: local_costmap/costmap_raw
-    local_footprint_topic: local_costmap/published_footprint
-    local_frame: odom
-    max_rotational_vel: 1.0
-    min_rotational_vel: 0.4
-    robot_base_frame: base_link
-    rotational_acc_lim: 3.2
-    simulate_ahead_time: 2.0
-    spin:
-      plugin: nav2_behaviors::Spin
-    transform_tolerance: 0.1
-    wait:
-      plugin: nav2_behaviors::Wait
+    scan_topic: scan
+
 bt_navigator:
   ros__parameters:
-    action_server_result_timeout: 900.0
+    global_frame: map
+    robot_base_frame: base_link
+    odom_topic: /odom
     bt_loop_duration: 10
     default_server_timeout: 20
-    error_code_names:
-    - compute_path_error_code
-    - follow_path_error_code
-    global_frame: map
-    navigate_through_poses:
-      plugin: nav2_bt_navigator::NavigateThroughPosesNavigator
-    navigate_to_pose:
-      plugin: nav2_bt_navigator::NavigateToPoseNavigator
-    navigators:
-    - navigate_to_pose
-    - navigate_through_poses
-    odom_topic: /odom
-    robot_base_frame: base_link
     wait_for_service_timeout: 1000
-collision_monitor:
-  ros__parameters:
-    FootprintApproach:
-      action_type: approach
-      enabled: true
-      footprint_topic: /local_costmap/published_footprint
-      min_points: 6
-      simulation_time_step: 0.1
-      time_before_collision: 1.2
-      type: polygon
-      visualize: false
-    base_frame_id: base_footprint
-    base_shift_correction: true
-    cmd_vel_in_topic: cmd_vel_smoothed
-    cmd_vel_out_topic: cmd_vel
-    observation_sources:
-    - scan
-    odom_frame_id: odom
-    polygons:
-    - FootprintApproach
-    scan:
-      enabled: true
-      max_height: 2.0
-      min_height: 0.15
-      topic: scan
-      type: scan
-    source_timeout: 1.0
-    state_topic: collision_monitor_state
-    stop_pub_timeout: 2.0
-    transform_tolerance: 0.2
+    action_server_result_timeout: 900.0
+    navigators: ["navigate_to_pose", "navigate_through_poses"]
+    navigate_to_pose:
+      plugin: "nav2_bt_navigator::NavigateToPoseNavigator"
+    navigate_through_poses:
+      plugin: "nav2_bt_navigator::NavigateThroughPosesNavigator"
+    # 'default_nav_through_poses_bt_xml' and 'default_nav_to_pose_bt_xml' are use defaults:
+    # nav2_bt_navigator/navigate_to_pose_w_replanning_and_recovery.xml
+    # nav2_bt_navigator/navigate_through_poses_w_replanning_and_recovery.xml
+    # They can be set here or via a RewrittenYaml remap from a parent launch file to Nav2.
+
+    # plugin_lib_names is used to add custom BT plugins to the executor (vector of strings).
+    # Built-in plugins are added automatically
+    # plugin_lib_names: []
+
+    error_code_names:
+      - compute_path_error_code
+      - follow_path_error_code
+
 controller_server:
   ros__parameters:
+    controller_frequency: 20.0
+    costmap_update_timeout: 0.30
+    min_x_velocity_threshold: 0.001
+    min_y_velocity_threshold: 0.5
+    min_theta_velocity_threshold: 0.001
+    failure_tolerance: 0.3
+    progress_checker_plugins: ["progress_checker"]
+    goal_checker_plugins: ["general_goal_checker"] # "precise_goal_checker"
+    controller_plugins: ["FollowPath"]
+    use_realtime_priority: false
+
+    # Progress checker parameters
+    progress_checker:
+      plugin: "nav2_controller::SimpleProgressChecker"
+      required_movement_radius: 0.5
+      movement_time_allowance: 10.0
+    # Goal checker parameters
+    #precise_goal_checker:
+    #  plugin: "nav2_controller::SimpleGoalChecker"
+    #  xy_goal_tolerance: 0.25
+    #  yaw_goal_tolerance: 0.25
+    #  stateful: True
+    general_goal_checker:
+      stateful: True
+      plugin: "nav2_controller::SimpleGoalChecker"
+      xy_goal_tolerance: 0.25
+      yaw_goal_tolerance: 0.25
     FollowPath:
-      AckermannConstraints:
-        min_turning_r: 0.2
-      ConstraintCritic:
-        cost_power: 1
-        cost_weight: 4.0
-        enabled: true
-      CostCritic:
-        collision_cost: 1000000.0
-        consider_footprint: true
-        cost_power: 1
-        cost_weight: 3.81
-        critical_cost: 300.0
-        enabled: true
-        near_goal_distance: 1.0
-        trajectory_point_step: 2
-      GoalAngleCritic:
-        cost_power: 1
-        cost_weight: 3.0
-        enabled: true
-        threshold_to_consider: 0.5
-      GoalCritic:
-        cost_power: 1
-        cost_weight: 5.0
-        enabled: true
-        threshold_to_consider: 1.4
-      PathAlignCritic:
-        cost_power: 1
-        cost_weight: 14.0
-        enabled: true
-        max_path_occupancy_ratio: 0.05
-        offset_from_furthest: 20
-        threshold_to_consider: 0.5
-        trajectory_point_step: 4
-        use_path_orientations: false
-      PathAngleCritic:
-        cost_power: 1
-        cost_weight: 2.0
-        enabled: true
-        max_angle_to_furthest: 1.0
-        mode: 0
-        offset_from_furthest: 4
-        threshold_to_consider: 0.5
-      PathFollowCritic:
-        cost_power: 1
-        cost_weight: 5.0
-        enabled: true
-        offset_from_furthest: 5
-        threshold_to_consider: 1.4
-      PreferForwardCritic:
-        cost_power: 1
-        cost_weight: 5.0
-        enabled: true
-        threshold_to_consider: 0.5
-      TrajectoryVisualizer:
-        time_step: 3
-        trajectory_step: 5
+      plugin: "nav2_mppi_controller::MPPIController"
+      time_steps: 56
+      model_dt: 0.05
+      batch_size: 2000
       ax_max: 3.0
       ax_min: -3.0
       ay_max: 3.0
       az_max: 3.5
-      batch_size: 2000
-      critics:
-      - ConstraintCritic
-      - CostCritic
-      - GoalCritic
-      - GoalAngleCritic
-      - PathAlignCritic
-      - PathFollowCritic
-      - PathAngleCritic
-      - PreferForwardCritic
-      gamma: 0.015
-      iteration_count: 1
-      model_dt: 0.05
-      motion_model: DiffDrive
-      plugin: nav2_mppi_controller::MPPIController
-      prune_distance: 1.7
-      regenerate_noises: true
-      temperature: 0.3
-      time_steps: 56
-      transform_tolerance: 0.1
-      visualize: true
+      vx_std: 0.2
+      vy_std: 0.2
+      wz_std: 0.4
       vx_max: 0.5
       vx_min: -0.35
-      vx_std: 0.2
       vy_max: 0.5
-      vy_std: 0.2
       wz_max: 1.9
-      wz_std: 0.4
-    controller_frequency: 20.0
-    controller_plugins:
-    - FollowPath
-    costmap_update_timeout: 0.3
-    failure_tolerance: 0.3
-    general_goal_checker:
-      plugin: nav2_controller::SimpleGoalChecker
-      stateful: true
-      xy_goal_tolerance: 0.25
-      yaw_goal_tolerance: 0.25
-    goal_checker_plugins:
-    - general_goal_checker
-    min_theta_velocity_threshold: 0.001
-    min_x_velocity_threshold: 0.001
-    min_y_velocity_threshold: 0.5
-    progress_checker:
-      movement_time_allowance: 10.0
-      plugin: nav2_controller::SimpleProgressChecker
-      required_movement_radius: 0.5
-    progress_checker_plugins:
-    - progress_checker
-    use_realtime_priority: false
-docking_server:
-  ros__parameters:
-    base_frame: base_link
-    controller:
-      costmap_topic: /local_costmap/costmap_raw
-      dock_collision_threshold: 0.3
-      footprint_topic: /local_costmap/published_footprint
-      k_delta: 2.0
-      k_phi: 3.0
-      projection_time: 5.0
-      simulation_step: 0.1
+      iteration_count: 1
+      prune_distance: 1.7
       transform_tolerance: 0.1
-      use_collision_detection: true
-      v_linear_max: 0.15
-      v_linear_min: 0.15
-    controller_frequency: 50.0
-    dock_approach_timeout: 30.0
-    dock_backwards: false
-    dock_plugins:
-    - simple_charging_dock
-    dock_prestaging_tolerance: 0.5
-    fixed_frame: odom
-    initial_perception_timeout: 5.0
-    max_retries: 3
-    simple_charging_dock:
-      docking_threshold: 0.05
-      external_detection_rotation_pitch: -1.57
-      external_detection_rotation_roll: -1.57
-      external_detection_rotation_yaw: 0.0
-      external_detection_timeout: 1.0
-      external_detection_translation_x: -0.18
-      external_detection_translation_y: 0.0
-      filter_coef: 0.1
-      plugin: opennav_docking::SimpleChargingDock
-      staging_x_offset: -0.7
-      use_battery_status: false
-      use_external_detection_pose: true
-      use_stall_detection: false
-    undock_angular_tolerance: 0.1
-    undock_linear_tolerance: 0.05
-    wait_charge_timeout: 5.0
-global_costmap:
-  global_costmap:
-    ros__parameters:
-      always_send_full_costmap: true
-      global_frame: map
-      inflation_layer:
-        cost_scaling_factor: 3.0
-        inflation_radius: 0.7
-        plugin: nav2_costmap_2d::InflationLayer
-      obstacle_layer:
+      temperature: 0.3
+      gamma: 0.015
+      motion_model: "DiffDrive"
+      visualize: true
+      regenerate_noises: true
+      TrajectoryVisualizer:
+        trajectory_step: 5
+        time_step: 3
+      AckermannConstraints:
+        min_turning_r: 0.2
+      critics: [
+        "ConstraintCritic", "CostCritic", "GoalCritic",
+        "GoalAngleCritic", "PathAlignCritic", "PathFollowCritic",
+        "PathAngleCritic", "PreferForwardCritic"]
+      ConstraintCritic:
         enabled: true
-        observation_sources: scan
-        plugin: nav2_costmap_2d::ObstacleLayer
-        scan:
-          clearing: true
-          data_type: LaserScan
-          marking: true
-          max_obstacle_height: 2.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          topic: /scan
-      plugins:
-      - static_layer
-      - obstacle_layer
-      - inflation_layer
-      publish_frequency: 1.0
-      resolution: 0.05
-      robot_base_frame: base_link
-      robot_radius: 0.22
-      static_layer:
-        map_subscribe_transient_local: true
-        plugin: nav2_costmap_2d::StaticLayer
-      track_unknown_space: true
-      update_frequency: 1.0
+        cost_power: 1
+        cost_weight: 4.0
+      GoalCritic:
+        enabled: true
+        cost_power: 1
+        cost_weight: 5.0
+        threshold_to_consider: 1.4
+      GoalAngleCritic:
+        enabled: true
+        cost_power: 1
+        cost_weight: 3.0
+        threshold_to_consider: 0.5
+      PreferForwardCritic:
+        enabled: true
+        cost_power: 1
+        cost_weight: 5.0
+        threshold_to_consider: 0.5
+      CostCritic:
+        enabled: true
+        cost_power: 1
+        cost_weight: 3.81
+        critical_cost: 300.0
+        consider_footprint: true
+        collision_cost: 1000000.0
+        near_goal_distance: 1.0
+        trajectory_point_step: 2
+      PathAlignCritic:
+        enabled: true
+        cost_power: 1
+        cost_weight: 14.0
+        max_path_occupancy_ratio: 0.05
+        trajectory_point_step: 4
+        threshold_to_consider: 0.5
+        offset_from_furthest: 20
+        use_path_orientations: false
+      PathFollowCritic:
+        enabled: true
+        cost_power: 1
+        cost_weight: 5.0
+        offset_from_furthest: 5
+        threshold_to_consider: 1.4
+      PathAngleCritic:
+        enabled: true
+        cost_power: 1
+        cost_weight: 2.0
+        offset_from_furthest: 4
+        threshold_to_consider: 0.5
+        max_angle_to_furthest: 1.0
+        mode: 0
+      # TwirlingCritic:
+      #   enabled: true
+      #   twirling_cost_power: 1
+      #   twirling_cost_weight: 10.0
+
 local_costmap:
   local_costmap:
     ros__parameters:
-      always_send_full_costmap: true
-      global_frame: odom
-      height: 3
-      inflation_layer:
-        cost_scaling_factor: 3.0
-        inflation_radius: 0.7
-        plugin: nav2_costmap_2d::InflationLayer
-      plugins:
-      - voxel_layer
-      - inflation_layer
-      publish_frequency: 2.0
-      resolution: 0.05
-      robot_base_frame: base_link
-      robot_radius: 0.22
-      rolling_window: true
-      static_layer:
-        map_subscribe_transient_local: true
-        plugin: nav2_costmap_2d::StaticLayer
       update_frequency: 5.0
+      publish_frequency: 2.0
+      global_frame: odom
+      robot_base_frame: base_link
+      rolling_window: true
+      width: 3
+      height: 3
+      resolution: 0.05
+      robot_radius: 0.22
+      plugins: ["voxel_layer", "inflation_layer"]
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
+        cost_scaling_factor: 3.0
+        inflation_radius: 0.70
       voxel_layer:
-        enabled: true
-        mark_threshold: 0
-        max_obstacle_height: 2.0
-        observation_sources: scan
+        plugin: "nav2_costmap_2d::VoxelLayer"
+        enabled: True
+        publish_voxel_map: True
         origin_z: 0.0
-        plugin: nav2_costmap_2d::VoxelLayer
-        publish_voxel_map: true
-        scan:
-          clearing: true
-          data_type: LaserScan
-          marking: true
-          max_obstacle_height: 2.0
-          obstacle_max_range: 2.5
-          obstacle_min_range: 0.0
-          raytrace_max_range: 3.0
-          raytrace_min_range: 0.0
-          topic: /scan
         z_resolution: 0.05
         z_voxels: 16
-      width: 3
-loopback_simulator:
-  ros__parameters:
-    base_frame_id: base_footprint
-    map_frame_id: map
-    odom_frame_id: odom
-    scan_frame_id: base_scan
-    update_duration: 0.02
+        max_obstacle_height: 2.0
+        mark_threshold: 0
+        observation_sources: scan
+        scan:
+          topic: /scan
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+          raytrace_max_range: 3.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 2.5
+          obstacle_min_range: 0.0
+      static_layer:
+        plugin: "nav2_costmap_2d::StaticLayer"
+        map_subscribe_transient_local: True
+      always_send_full_costmap: True
+
+global_costmap:
+  global_costmap:
+    ros__parameters:
+      update_frequency: 1.0
+      publish_frequency: 1.0
+      global_frame: map
+      robot_base_frame: base_link
+      robot_radius: 0.22
+      resolution: 0.05
+      track_unknown_space: true
+      plugins: ["static_layer", "obstacle_layer", "inflation_layer"]
+      obstacle_layer:
+        plugin: "nav2_costmap_2d::ObstacleLayer"
+        enabled: True
+        observation_sources: scan
+        scan:
+          topic: /scan
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+          raytrace_max_range: 3.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 2.5
+          obstacle_min_range: 0.0
+      static_layer:
+        plugin: "nav2_costmap_2d::StaticLayer"
+        map_subscribe_transient_local: True
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
+        cost_scaling_factor: 3.0
+        inflation_radius: 0.7
+      always_send_full_costmap: True
+
+# The yaml_filename does not need to be specified since it going to be set by defaults in launch.
+# If you'd rather set it in the yaml, remove the default "map" value in the tb3_simulation_launch.py
+# file & provide full path to map below. If CLI map configuration or launch default is provided, that will be used.
+# map_server:
+#   ros__parameters:
+#     yaml_filename: ""
+
 map_saver:
   ros__parameters:
-    free_thresh_default: 0.25
-    map_subscribe_transient_local: true
-    occupied_thresh_default: 0.65
     save_map_timeout: 5.0
+    free_thresh_default: 0.25
+    occupied_thresh_default: 0.65
+    map_subscribe_transient_local: True
+
 planner_server:
   ros__parameters:
+    expected_planner_frequency: 20.0
+    planner_plugins: ["GridBased"]
+    costmap_update_timeout: 1.0
     GridBased:
-      allow_unknown: true
-      plugin: nav2_navfn_planner::NavfnPlanner
+      plugin: "nav2_navfn_planner::NavfnPlanner"
       tolerance: 0.5
       use_astar: false
-    costmap_update_timeout: 1.0
-    expected_planner_frequency: 20.0
-    planner_plugins:
-    - GridBased
+      allow_unknown: true
+
 smoother_server:
   ros__parameters:
+    smoother_plugins: ["simple_smoother"]
     simple_smoother:
-      do_refinement: true
-      max_its: 1000
-      plugin: nav2_smoother::SimpleSmoother
+      plugin: "nav2_smoother::SimpleSmoother"
       tolerance: 1.0e-10
-    smoother_plugins:
-    - simple_smoother
-velocity_smoother:
+      max_its: 1000
+      do_refinement: True
+
+behavior_server:
   ros__parameters:
-    deadband_velocity:
-    - 0.0
-    - 0.0
-    - 0.0
-    feedback: OPEN_LOOP
-    max_accel:
-    - 2.5
-    - 0.0
-    - 3.2
-    max_decel:
-    - -2.5
-    - 0.0
-    - -3.2
-    max_velocity:
-    - 0.5
-    - 0.0
-    - 2.0
-    min_velocity:
-    - -0.5
-    - 0.0
-    - -2.0
-    odom_duration: 0.1
-    odom_topic: odom
-    scale_velocities: false
-    smoothing_frequency: 20.0
-    velocity_timeout: 1.0
+    local_costmap_topic: local_costmap/costmap_raw
+    global_costmap_topic: global_costmap/costmap_raw
+    local_footprint_topic: local_costmap/published_footprint
+    global_footprint_topic: global_costmap/published_footprint
+    cycle_frequency: 10.0
+    behavior_plugins: ["spin", "backup", "drive_on_heading", "assisted_teleop", "wait"]
+    spin:
+      plugin: "nav2_behaviors::Spin"
+    backup:
+      plugin: "nav2_behaviors::BackUp"
+    drive_on_heading:
+      plugin: "nav2_behaviors::DriveOnHeading"
+    wait:
+      plugin: "nav2_behaviors::Wait"
+    assisted_teleop:
+      plugin: "nav2_behaviors::AssistedTeleop"
+    local_frame: odom
+    global_frame: map
+    robot_base_frame: base_link
+    transform_tolerance: 0.1
+    simulate_ahead_time: 2.0
+    max_rotational_vel: 1.0
+    min_rotational_vel: 0.4
+    rotational_acc_lim: 3.2
+
 waypoint_follower:
   ros__parameters:
-    action_server_result_timeout: 900.0
     loop_rate: 20
     stop_on_failure: false
+    action_server_result_timeout: 900.0
+    waypoint_task_executor_plugin: "wait_at_waypoint"
     wait_at_waypoint:
-      enabled: true
-      plugin: nav2_waypoint_follower::WaitAtWaypoint
+      plugin: "nav2_waypoint_follower::WaitAtWaypoint"
+      enabled: True
       waypoint_pause_duration: 200
-    waypoint_task_executor_plugin: wait_at_waypoint
+
+velocity_smoother:
+  ros__parameters:
+    smoothing_frequency: 20.0
+    scale_velocities: False
+    feedback: "OPEN_LOOP"
+    max_velocity: [0.5, 0.0, 2.0]
+    min_velocity: [-0.5, 0.0, -2.0]
+    max_accel: [2.5, 0.0, 3.2]
+    max_decel: [-2.5, 0.0, -3.2]
+    odom_topic: "odom"
+    odom_duration: 0.1
+    deadband_velocity: [0.0, 0.0, 0.0]
+    velocity_timeout: 1.0
+
+collision_monitor:
+  ros__parameters:
+    base_frame_id: "base_footprint"
+    odom_frame_id: "odom"
+    cmd_vel_in_topic: "cmd_vel_smoothed"
+    cmd_vel_out_topic: "cmd_vel"
+    state_topic: "collision_monitor_state"
+    transform_tolerance: 0.2
+    source_timeout: 1.0
+    base_shift_correction: True
+    stop_pub_timeout: 2.0
+    # Polygons represent zone around the robot for "stop", "slowdown" and "limit" action types,
+    # and robot footprint for "approach" action type.
+    polygons: ["FootprintApproach"]
+    FootprintApproach:
+      type: "polygon"
+      action_type: "approach"
+      footprint_topic: "/local_costmap/published_footprint"
+      time_before_collision: 1.2
+      simulation_time_step: 0.1
+      min_points: 6
+      visualize: False
+      enabled: True
+    observation_sources: ["scan"]
+    scan:
+      type: "scan"
+      topic: "scan"
+      min_height: 0.15
+      max_height: 2.0
+      enabled: True
+
+docking_server:
+  ros__parameters:
+    controller_frequency: 50.0
+    initial_perception_timeout: 5.0
+    wait_charge_timeout: 5.0
+    dock_approach_timeout: 30.0
+    undock_linear_tolerance: 0.05
+    undock_angular_tolerance: 0.1
+    max_retries: 3
+    base_frame: "base_link"
+    fixed_frame: "odom"
+    dock_backwards: false
+    dock_prestaging_tolerance: 0.5
+
+    # Types of docks
+    dock_plugins: ['simple_charging_dock']
+    simple_charging_dock:
+      plugin: 'opennav_docking::SimpleChargingDock'
+      docking_threshold: 0.05
+      staging_x_offset: -0.7
+      use_external_detection_pose: true
+      use_battery_status: false # true
+      use_stall_detection: false # true
+
+      external_detection_timeout: 1.0
+      external_detection_translation_x: -0.18
+      external_detection_translation_y: 0.0
+      external_detection_rotation_roll: -1.57
+      external_detection_rotation_pitch: -1.57
+      external_detection_rotation_yaw: 0.0
+      filter_coef: 0.1
+
+    # Dock instances
+    # The following example illustrates configuring dock instances.
+    # docks: ['home_dock']  # Input your docks here
+    # home_dock:
+    #   type: 'simple_charging_dock'
+    #   frame: map
+    #   pose: [0.0, 0.0, 0.0]
+
+    controller:
+      k_phi: 3.0
+      k_delta: 2.0
+      v_linear_min: 0.15
+      v_linear_max: 0.15
+      use_collision_detection: true
+      costmap_topic: "/local_costmap/costmap_raw"
+      footprint_topic: "/local_costmap/published_footprint"
+      transform_tolerance: 0.1
+      projection_time: 5.0
+      simulation_step: 0.1
+      dock_collision_threshold: 0.3
+
+loopback_simulator:
+  ros__parameters:
+    base_frame_id: "base_footprint"
+    odom_frame_id: "odom"
+    map_frame_id: "map"
+    scan_frame_id: "base_scan"  # tb4_loopback_simulator.launch.py remaps to 'rplidar_link'
+    update_duration: 0.02

--- a/linorobot2_navigation/rviz/linorobot2_navigation.rviz
+++ b/linorobot2_navigation/rviz/linorobot2_navigation.rviz
@@ -4,14 +4,12 @@ Panels:
     Name: Displays
     Property Tree Widget:
       Expanded:
+        - /Global Options1
         - /TF1/Frames1
         - /TF1/Tree1
-        - /Amcl Particle Swarm1
-        - /Global Planner1/Path1
-        - /Controller1/Local Costmap1
-        - /Controller1/Local Plan1
+        - /LaserScan1
       Splitter Ratio: 0.5833333134651184
-    Tree Height: 724
+    Tree Height: 225
   - Class: rviz_common/Selection
     Name: Selection
   - Class: rviz_common/Tool Properties
@@ -23,16 +21,20 @@ Panels:
     Expanded:
       - /Current View1
     Name: Views
-    Splitter Ratio: 0.5
+    Splitter Ratio: 0.3333333432674408
   - Class: nav2_rviz_plugins/Navigation 2
     Name: Navigation 2
+  - Class: nav2_rviz_plugins/Selector
+    Name: Selector
+  - Class: nav2_rviz_plugins/Docking
+    Name: Docking
 Visualization Manager:
   Class: ""
   Displays:
-    - Alpha: 0.30000001192092896
+    - Alpha: 0.5
       Cell Size: 1
       Class: rviz_default_plugins/Grid
-      Color: 32; 74; 135
+      Color: 160; 160; 164
       Enabled: true
       Line Style:
         Line Width: 0.029999999329447746
@@ -44,7 +46,7 @@ Visualization Manager:
         Y: 0
         Z: 0
       Plane: XY
-      Plane Cell Count: 1000
+      Plane Cell Count: 10
       Reference Frame: <Fixed Frame>
       Value: true
     - Alpha: 1
@@ -58,98 +60,133 @@ Visualization Manager:
         History Policy: Keep Last
         Reliability Policy: Reliable
         Value: /robot_description
-      Enabled: false
+      Enabled: true
       Links:
         All Links Enabled: true
         Expand Joint Details: false
         Expand Link Details: false
         Expand Tree: false
-        Link Tree Style: ""
+        Link Tree Style: Links in Alphabetic Order
+        base_footprint:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        camera_depth_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        camera_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        imu_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        laser:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        left_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        rear_caster_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_wheel_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        sonar_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+      Mass Properties:
+        Inertia: false
+        Mass: false
       Name: RobotModel
       TF Prefix: ""
       Update Interval: 0
-      Value: false
+      Value: true
       Visual Enabled: true
     - Class: rviz_default_plugins/TF
       Enabled: true
+      Filter (blacklist): ""
+      Filter (whitelist): ""
       Frame Timeout: 15
       Frames:
         All Enabled: false
         base_footprint:
           Value: true
         base_link:
-          Value: false
+          Value: true
+        camera_depth_link:
+          Value: true
         camera_link:
-          Value: false
-        front_left_wheel_link:
-          Value: false
-        front_right_wheel_link:
-          Value: false
+          Value: true
         imu_link:
-          Value: false
+          Value: true
         laser:
-          Value: false
-        map:
-          Value: false
+          Value: true
+        left_wheel_link:
+          Value: true
         odom:
-          Value: false
-        rear_left_wheel_link:
-          Value: false
-        rear_right_wheel_link:
-          Value: false
-      Marker Scale: 2
+          Value: true
+        rear_caster_wheel_link:
+          Value: true
+        right_wheel_link:
+          Value: true
+        sonar_link:
+          Value: true
+      Marker Scale: 1
       Name: TF
       Show Arrows: true
       Show Axes: true
       Show Names: false
       Tree:
-        map:
-          odom:
-            base_footprint:
-              base_link:
-                camera_link:
-                  {}
-                imu_link:
-                  {}
-                laser:
-                  {}
-              front_left_wheel_link:
-                {}
-              front_right_wheel_link:
-                {}
-              rear_left_wheel_link:
-                {}
-              rear_right_wheel_link:
-                {}
+        {}
       Update Interval: 0
       Value: true
     - Alpha: 1
       Autocompute Intensity Bounds: true
       Autocompute Value Bounds:
-        Max Value: 3.290379285812378
-        Min Value: -10.208759307861328
+        Max Value: 10
+        Min Value: -10
         Value: true
-      Axis: X
+      Axis: Z
       Channel Name: intensity
       Class: rviz_default_plugins/LaserScan
       Color: 255; 255; 255
-      Color Transformer: AxisColor
+      Color Transformer: Intensity
       Decay Time: 0
       Enabled: true
       Invert Rainbow: false
       Max Color: 255; 255; 255
-      Max Intensity: 0
+      Max Intensity: 255
       Min Color: 0; 0; 0
-      Min Intensity: 0
+      Min Intensity: 15
       Name: LaserScan
       Position Transformer: XYZ
       Selectable: true
-      Size (Pixels): 3
-      Size (m): 0.10000000149011612
-      Style: Flat Squares
+      Size (Pixels): 10
+      Size (m): 0.009999999776482582
+      Style: Points
       Topic:
         Depth: 5
         Durability Policy: Volatile
+        Filter size: 10
         History Policy: Keep Last
         Reliability Policy: Best Effort
         Value: /scan
@@ -190,6 +227,8 @@ Visualization Manager:
       Use rainbow: true
       Value: true
     - Alpha: 1
+      Binary representation: false
+      Binary threshold: 100
       Class: rviz_default_plugins/Map
       Color Scheme: map
       Draw Behind: true
@@ -198,6 +237,7 @@ Visualization Manager:
       Topic:
         Depth: 1
         Durability Policy: Transient Local
+        Filter size: 10
         History Policy: Keep Last
         Reliability Policy: Reliable
         Value: /map
@@ -209,37 +249,36 @@ Visualization Manager:
         Value: /map_updates
       Use Timestamp: false
       Value: true
-    - Alpha: 0.20000000298023224
-      Arrow Length: 0.10000000149011612
-      Axes Length: 0.30000001192092896
-      Axes Radius: 0.009999999776482582
-      Class: rviz_default_plugins/PoseArray
-      Color: 173; 127; 168
+    - Alpha: 1
+      Class: nav2_rviz_plugins/ParticleCloud
+      Color: 0; 180; 0
       Enabled: true
-      Head Length: 0.07000000029802322
-      Head Radius: 0.029999999329447746
+      Max Arrow Length: 0.30000001192092896
+      Min Arrow Length: 0.019999999552965164
       Name: Amcl Particle Swarm
-      Shaft Length: 0.23000000417232513
-      Shaft Radius: 0.009999999776482582
       Shape: Arrow (Flat)
       Topic:
         Depth: 5
         Durability Policy: Volatile
+        Filter size: 10
         History Policy: Keep Last
         Reliability Policy: Best Effort
-        Value: /particlecloud
+        Value: /particle_cloud
       Value: true
     - Class: rviz_common/Group
       Displays:
-        - Alpha: 0.20000000298023224
+        - Alpha: 0.30000001192092896
+          Binary representation: false
+          Binary threshold: 100
           Class: rviz_default_plugins/Map
-          Color Scheme: map
+          Color Scheme: costmap
           Draw Behind: false
           Enabled: true
           Name: Global Costmap
           Topic:
             Depth: 1
             Durability Policy: Transient Local
+            Filter size: 10
             History Policy: Keep Last
             Reliability Policy: Reliable
             Value: /global_costmap/costmap
@@ -252,6 +291,8 @@ Visualization Manager:
           Use Timestamp: false
           Value: true
         - Alpha: 0.30000001192092896
+          Binary representation: false
+          Binary threshold: 100
           Class: rviz_default_plugins/Map
           Color Scheme: costmap
           Draw Behind: false
@@ -260,6 +301,7 @@ Visualization Manager:
           Topic:
             Depth: 1
             Durability Policy: Transient Local
+            Filter size: 10
             History Policy: Keep Last
             Reliability Policy: Reliable
             Value: /downsampled_costmap
@@ -271,29 +313,30 @@ Visualization Manager:
             Value: /downsampled_costmap_updates
           Use Timestamp: false
           Value: true
-        - Alpha: 0.5
+        - Alpha: 1
           Buffer Length: 1
           Class: rviz_default_plugins/Path
-          Color: 78; 154; 6
+          Color: 255; 0; 0
           Enabled: true
-          Head Diameter: 0.05000000074505806
-          Head Length: 0.05000000074505806
+          Head Diameter: 0.019999999552965164
+          Head Length: 0.019999999552965164
           Length: 0.30000001192092896
-          Line Style: Billboards
-          Line Width: 0.10000000149011612
+          Line Style: Lines
+          Line Width: 0.029999999329447746
           Name: Path
           Offset:
             X: 0
             Y: 0
             Z: 0
-          Pose Color: 173; 127; 168
-          Pose Style: None
+          Pose Color: 255; 85; 255
+          Pose Style: Arrows
           Radius: 0.029999999329447746
-          Shaft Diameter: 0.009999999776482582
-          Shaft Length: 0.10000000149011612
+          Shaft Diameter: 0.004999999888241291
+          Shaft Length: 0.019999999552965164
           Topic:
             Depth: 5
             Durability Policy: Volatile
+            Filter size: 10
             History Policy: Keep Last
             Reliability Policy: Reliable
             Value: /plan
@@ -306,7 +349,7 @@ Visualization Manager:
             Value: true
           Axis: Z
           Channel Name: intensity
-          Class: rviz_default_plugins/PointCloud
+          Class: rviz_default_plugins/PointCloud2
           Color: 125; 125; 125
           Color Transformer: FlatColor
           Decay Time: 0
@@ -339,6 +382,7 @@ Visualization Manager:
           Topic:
             Depth: 5
             Durability Policy: Volatile
+            Filter size: 10
             History Policy: Keep Last
             Reliability Policy: Reliable
             Value: /global_costmap/published_footprint
@@ -347,7 +391,9 @@ Visualization Manager:
       Name: Global Planner
     - Class: rviz_common/Group
       Displays:
-        - Alpha: 0.5
+        - Alpha: 0.699999988079071
+          Binary representation: false
+          Binary threshold: 100
           Class: rviz_default_plugins/Map
           Color Scheme: costmap
           Draw Behind: false
@@ -356,6 +402,7 @@ Visualization Manager:
           Topic:
             Depth: 1
             Durability Policy: Transient Local
+            Filter size: 10
             History Policy: Keep Last
             Reliability Policy: Reliable
             Value: /local_costmap/costmap
@@ -367,7 +414,7 @@ Visualization Manager:
             Value: /local_costmap/costmap_updates
           Use Timestamp: false
           Value: true
-        - Alpha: 0.5
+        - Alpha: 1
           Buffer Length: 1
           Class: rviz_default_plugins/Path
           Color: 0; 12; 255
@@ -375,8 +422,8 @@ Visualization Manager:
           Head Diameter: 0.30000001192092896
           Head Length: 0.20000000298023224
           Length: 0.30000001192092896
-          Line Style: Billboards
-          Line Width: 0.20000000298023224
+          Line Style: Lines
+          Line Width: 0.029999999329447746
           Name: Local Plan
           Offset:
             X: 0
@@ -390,6 +437,7 @@ Visualization Manager:
           Topic:
             Depth: 5
             Durability Policy: Volatile
+            Filter size: 10
             History Policy: Keep Last
             Reliability Policy: Reliable
             Value: /local_plan
@@ -414,6 +462,7 @@ Visualization Manager:
           Topic:
             Depth: 5
             Durability Policy: Volatile
+            Filter size: 10
             History Policy: Keep Last
             Reliability Policy: Reliable
             Value: /local_costmap/published_footprint
@@ -426,7 +475,7 @@ Visualization Manager:
             Value: true
           Axis: Z
           Channel Name: intensity
-          Class: rviz_default_plugins/PointCloud
+          Class: rviz_default_plugins/PointCloud2
           Color: 255; 255; 255
           Color Transformer: RGB8
           Decay Time: 0
@@ -516,75 +565,9 @@ Visualization Manager:
         Reliability Policy: Reliable
         Value: /waypoints
       Value: true
-    - Alpha: 1
-      Class: rviz_default_plugins/RobotModel
-      Collision Enabled: false
-      Description File: ""
-      Description Source: Topic
-      Description Topic:
-        Depth: 5
-        Durability Policy: Volatile
-        History Policy: Keep Last
-        Reliability Policy: Reliable
-        Value: /robot_description
-      Enabled: true
-      Links:
-        All Links Enabled: true
-        Expand Joint Details: false
-        Expand Link Details: false
-        Expand Tree: false
-        Link Tree Style: Links in Alphabetic Order
-        base_footprint:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-        base_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        camera_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        front_left_wheel_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        front_right_wheel_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        imu_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-        laser:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        rear_left_wheel_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-        rear_right_wheel_link:
-          Alpha: 1
-          Show Axes: false
-          Show Trail: false
-          Value: true
-      Name: RobotModel
-      TF Prefix: ""
-      Update Interval: 0
-      Value: true
-      Visual Enabled: true
   Enabled: true
   Global Options:
-    Background Color: 255; 255; 255
+    Background Color: 48; 48; 48
     Fixed Frame: map
     Frame Rate: 30
   Name: root
@@ -595,6 +578,9 @@ Visualization Manager:
     - Class: rviz_default_plugins/Measure
       Line color: 128; 128; 0
     - Class: rviz_default_plugins/SetInitialPose
+      Covariance x: 0.25
+      Covariance y: 0.25
+      Covariance yaw: 0.06853891909122467
       Topic:
         Depth: 5
         Durability Policy: Volatile
@@ -616,7 +602,7 @@ Visualization Manager:
   Value: true
   Views:
     Current:
-      Angle: 0
+      Angle: -0.0008007669821381569
       Class: rviz_default_plugins/TopDownOrtho
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
@@ -626,29 +612,33 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Scale: 71.72926330566406
-      Target Frame: base_link
+      Scale: 76.76630401611328
+      Target Frame: <Fixed Frame>
       Value: TopDownOrtho (rviz_default_plugins)
-      X: 0.4037398099899292
-      Y: 0.7326793670654297
+      X: -0.07227574288845062
+      Y: -0.22131918370723724
     Saved: ~
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 1136
+  Docking:
+    collapsed: false
+  Height: 893
   Hide Left Dock: false
-  Hide Right Dock: true
+  Hide Right Dock: false
   Navigation 2:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd00000004000000000000015600000416fc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d00000311000000c900fffffffb00000018004e0061007600690067006100740069006f006e002000320100000354000000ff000000b700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000001e005200650061006c00730065006e0073006500430061006d00650072006100000002c6000000c10000002800ffffff00000001000001c60000034afc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d0000034a000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000750000000b7fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004420000003efc0100000002fb0000000800540069006d00650100000000000004420000000000000000fb0000000800540069006d00650100000000000004500000000000000000000005f40000041600000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000400000000000001560000031ffc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005d00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000100044006900730070006c006100790073010000003f00000121000000cc00fffffffb00000018004e0061007600690067006100740069006f006e002000320100000166000001f8000001f800fffffffb0000001e005200650061006c00730065006e0073006500430061006d00650072006100000002c6000000c10000001700ffffff00000001000001470000031ffc0200000005fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003f000000de000000a900fffffffb0000000e0044006f0063006b0069006e00670100000123000001620000016200fffffffb0000001000530065006c006500630074006f0072010000028b000000d3000000d300fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004420000003efc0100000002fb0000000800540069006d00650100000000000004420000000000000000fb0000000800540069006d00650100000000000004500000000000000000000003a10000031f00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   RealsenseCamera:
     collapsed: false
   Selection:
     collapsed: false
+  Selector:
+    collapsed: false
   Tool Properties:
     collapsed: false
   Views:
-    collapsed: true
-  Width: 1872
-  X: 48
-  Y: 27
+    collapsed: false
+  Width: 1610
+  X: 174
+  Y: 75


### PR DESCRIPTION
I found the navigation.yaml I pulled from /tmp is not the same as what's in nav2_bringup/params/nav2_params.yaml, and that was the intent. Specifically, some topic names were missing quotes around them, and the whole thing was swizzled differently, and just didn't work well. This change makes the change that was intended by the previous PR: to make navigation.yaml be the same as in ros2-jazzy.

Separately, the linorobot2_navigation.rviz file wouldn't show the amcl pointcloud. The amcl config in the rviz tool looked right, but it just didn't work. This PR pushes the rviz config from nav2_bringup/rviz/nav2_default_view.rviz into linorobot2_navigation/rviz/linorobot2_navigation.rviz.