### PR TITLE
fix to react to change in nav2 stack

### DIFF
--- a/linorobot2_navigation/config/navigation.yaml
+++ b/linorobot2_navigation/config/navigation.yaml
@@ -151,7 +151,7 @@ controller_server:
         cost_power: 1
         cost_weight: 3.81
         critical_cost: 300.0
-        consider_footprint: true
+        consider_footprint: false
         collision_cost: 1000000.0
         near_goal_distance: 1.0
         trajectory_point_step: 2


### PR DESCRIPTION
About a month ago, someone changed the nav2 stack to check that the footprint used by the local planner matches the footprint used by the global planner. In this config file, they are different, which caused the nav stack to stop and crash. Changing the consider_footprint parameter to false disables this check. This parameter now matches what's in nav2_params.yaml.