### PR TITLE
Set speeds & accelerations to what they were in the humble nav params

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Set LINOROBOT2_BASE env variable to the type of robot base used. Available env v
 
 You can skip the next step (Host Machine - RVIZ Configurations) since this package already contains the same RVIZ configurations to visualize the robot. 
 
-### 3. Host Machine - RVIZ Configurations
+### 3. Host Machine - RVIZ Configuration
 Install [linorobot2_viz](https://github.com/linorobot/linorobot2_viz) package to visualize the robot remotely specifically when creating a map or initializing/sending goal poses to the robot. The package has been separated to minimize the installation required if you're not using the simulation tools on the host machine.
 
     cd <host_machine_ws>
@@ -96,6 +96,13 @@ Install [linorobot2_viz](https://github.com/linorobot/linorobot2_viz) package to
     rosdep update && rosdep install --from-path src --ignore-src -y 
     colcon build
     source install/setup.bash
+
+### 4. Docker Configuration
+Docker can be used to run linorobot2 on a host machine for simulation. You might need to customize the docker/.env file.
+
+    git clone https://github.com/linorobot/linorobot2.git
+    cd linorobot2/docker
+    sudo docker compose build
 
 ## Hardware and Robot Firmware
 All the hardware documentation and robot microcontroller's firmware can be found [here](https://github.com/linorobot/linorobot2_hardware).
@@ -201,6 +208,23 @@ The agent needs a few seconds to get reconnected (less than 30 seconds). Unplug 
     ros2 launch linorobot2_gazebo gazebo.launch.py
 
 linorobot2_bringup.launch.py or gazebo.launch.py must always be run on a separate terminal before creating a map or robot navigation when working on a real robot or gazebo simulation respectively.
+
+#### 1.1c Using Gazebo simulation in a Docker container:
+
+You can run gazebo in a docker container and start navigation.
+You must have previously built the docker image. The following commands are run with sudo, but follow the docker post-install
+instructions to enable docker commands to be run without sudo.
+
+cd to the docker directory and run the following command:
+
+    sudo docker compose up -d gazebo navigate-sim
+
+Gazebo will start and display the world, and nav2 will start along with an rviz window. You can set the initial position of the robot
+and give it goal poses to navigate to. Note you cannot run some of the system in a docker container and other parts natively on the docker host.
+
+You can look at logs from the ROS nodes by running
+
+    sudo docker compose logs
 
 ### 2. Controlling the robot
 #### 2.1  Keyboard Teleop

--- a/docker/.env
+++ b/docker/.env
@@ -2,7 +2,7 @@
 ROBOT_BASE=2wd
 
 # 2D laser scanner to be used. Available variables: ldlidar rplidar ydlidar xv11
-LASER_SENSOR=
+LASER_SENSOR=ldlidar
 
 # Depth sensor to be used. Available variables: realsense zed zedm zed2 zed2i
 DEPTH_SENSOR=
@@ -35,8 +35,8 @@ LAUNCH_JOYSTICK=false
 # leave blank to disable
 RUNTIME=
 
-UBUNTU_VER=22.04
-USE_ROS_DISTRO=humble
+UBUNTU_VER=24.04
+USE_ROS_DISTRO=jazzy
 
 RMW=cyclonedds
 # RMW=fastrtps

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,20 +91,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libx11-6 \
     && rm -rf /var/lib/apt/lists/*
 
-# Install ROS2
+# Install ROS2 using updated procedure from jazzy install docs
 ARG USE_ROS_DISTRO=
-RUN add-apt-repository universe \
-        && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
-        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null \
-        && apt-get update && apt-get install -y --no-install-recommends \
-            ros-${USE_ROS_DISTRO}-ros-base \
-            python3-argcomplete \
-    && rm -rf /var/lib/apt/lists/*
+RUN add-apt-repository universe
+RUN export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}') \
+         && curl -L -o ./ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" \
+         && apt install ./ros2-apt-source.deb
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ros-dev-tools \
         ros-${USE_ROS_DISTRO}-ament-* \
     && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get upgrade && apt install -y --no-install-recommends \
+        ros-${USE_ROS_DISTRO}-ros-base \
+        python3-argcomplete \
+    && rm -rf /var/lib/apt/lists/*
+
 
 RUN source /opt/ros/${USE_ROS_DISTRO}/setup.bash
 RUN rosdep init 
@@ -200,8 +203,7 @@ SHELL ["/bin/bash", "-c"]
 RUN curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg;
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null;
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        gz-harmonic \
-        ros-humble-ros-gzharmonic \  
+        ros-jazzy-ros-gz \  
     && rm -rf /var/lib/apt/lists/*
 
 # Classic Gazebo

--- a/linorobot2_navigation/config/navigation.yaml
+++ b/linorobot2_navigation/config/navigation.yaml
@@ -113,7 +113,7 @@ controller_server:
       min_lookahead_dist: 0.3
       max_lookahead_dist: 0.9
       lookahead_time: 1.5
-      rotate_to_heading_angular_vel: 1.8
+      rotate_to_heading_angular_vel: 0.75
       transform_tolerance: 0.1
       use_velocity_scaled_lookahead_dist: false
       min_approach_linear_velocity: 0.05
@@ -286,8 +286,8 @@ velocity_smoother:
     smoothing_frequency: 20.0
     scale_velocities: False
     feedback: "OPEN_LOOP"
-    max_velocity: [0.5, 0.0, 2.0]
-    min_velocity: [-0.5, 0.0, -2.0]
+    max_velocity: [0.5, 0.0, 2.5]
+    min_velocity: [-0.5, 0.0, -2.5]
     max_accel: [2.5, 0.0, 3.2]
     max_decel: [-2.5, 0.0, -3.2]
     odom_topic: "odom"

--- a/linorobot2_navigation/config/navigation_sim.yaml
+++ b/linorobot2_navigation/config/navigation_sim.yaml
@@ -113,7 +113,7 @@ controller_server:
       min_lookahead_dist: 0.3
       max_lookahead_dist: 0.9
       lookahead_time: 1.5
-      rotate_to_heading_angular_vel: 1.8
+      rotate_to_heading_angular_vel: 0.75
       transform_tolerance: 0.1
       use_velocity_scaled_lookahead_dist: false
       min_approach_linear_velocity: 0.05
@@ -286,8 +286,8 @@ velocity_smoother:
     smoothing_frequency: 20.0
     scale_velocities: False
     feedback: "OPEN_LOOP"
-    max_velocity: [0.5, 0.0, 2.0]
-    min_velocity: [-0.5, 0.0, -2.0]
+    max_velocity: [0.5, 0.0, 2.5]
+    min_velocity: [-0.5, 0.0, -2.5]
     max_accel: [2.5, 0.0, 3.2]
     max_decel: [-2.5, 0.0, -3.2]
     odom_topic: "odom"


### PR DESCRIPTION
Set linear & rotational speeds & accelerations to what they were in the humble-based nav params file.

Tested in sim & on hardware. My impression is it's rotating a little slower and a little more controlled - I saw no overshoot, on rotation at the end of the move, which is an improvement.